### PR TITLE
Add hass-access via nebula iptables rule

### DIFF
--- a/nebula/Dockerfile
+++ b/nebula/Dockerfile
@@ -14,6 +14,7 @@ RUN \
         go=1.20.7-r0 \
         iptables=1.8.9-r2 \
         yq=4.33.3-r2 \
+        bind-tools=9.18.16-r0 \
 #        libqrencode=4.1.1-r0 \
 #        openresolv=3.12.0-r0 \
 #        wireguard-tools=1.0.20210914-r0 \

--- a/nebula/Dockerfile
+++ b/nebula/Dockerfile
@@ -11,10 +11,10 @@ RUN \
         git=2.40.1-r0 \
     \
     && apk add --no-cache \
-        go=1.20.7-r0 \
-        iptables=1.8.9-r2 \
-        yq=4.33.3-r2 \
-        bind-tools=9.18.16-r0 \
+        go \
+        iptables \
+        yq \
+        bind-tools \
 #        libqrencode=4.1.1-r0 \
 #        openresolv=3.12.0-r0 \
 #        wireguard-tools=1.0.20210914-r0 \

--- a/nebula/rootfs/etc/cont-init.d/config.sh
+++ b/nebula/rootfs/etc/cont-init.d/config.sh
@@ -213,6 +213,12 @@ else
       --jump MASQUERADE
 fi
 
+# TODO: This is annoying syntax, need a better way to look this up
+for idx in $(bashio::config 'node_list|keys'); do
+    hass_overlay_ip=$(bashio::config "node_list[${idx}].overlay_ip")
+    break
+done
+
 # This host should route traffic coming to the nebula interface+IP to the host IP to reach hass services via the nebula IP
 iptables --table nat --append PREROUTING \
   --in-interface "${nebula_interface_name}" --destination ${hass_overlay_ip} \

--- a/nebula/rootfs/etc/cont-init.d/config.sh
+++ b/nebula/rootfs/etc/cont-init.d/config.sh
@@ -189,6 +189,13 @@ fi
 # TODO: Make this optionally configurable
 nebula_interface_name=nebula1
 host_interface_name=eth0
+# Accept traffic on the nebula interface not destined for my IPs
 iptables -A FORWARD -i "${nebula_interface_name}" -j ACCEPT
+# Accept traffic exiting the nebula interface not destined for my IPs
 iptables -A FORWARD -o "${nebula_interface_name}" -j ACCEPT
+# After routing has finished
 iptables -t nat -A POSTROUTING -o "${host_interface_name}" -j MASQUERADE
+
+homeassistant_ip=$(dig +short homeassistant)
+# We want this host to receive traffic coming to the nebula interface and route it to the host IP instead so you can access hass services using the nebula IP
+iptables -A PREROUTING -i "${nebula_interface_name}" -j DNAT --to-destination ${homeassistant_ip}

--- a/nebula/rootfs/etc/cont-init.d/config.sh
+++ b/nebula/rootfs/etc/cont-init.d/config.sh
@@ -214,6 +214,6 @@ else
 fi
 
 # This host should route traffic coming to the nebula interface+IP to the host IP to reach hass services via the nebula IP
-iptables --append PREROUTING \
+iptables --table nat --append PREROUTING \
   --in-interface "${nebula_interface_name}" --destination ${hass_overlay_ip} \
   --jump DNAT --to-destination ${hass_underlay_ip}


### PR DESCRIPTION
This adds a routing rule so that traffic that comes in to 10.11.11.9 gets redirected to the non-nebula IP for home assistant leaving home assistant accessible without any unsafe_routes setup. (technically the internal docker gateway IP, but I don't know how that black magic works, I just know the traffic ends up in the right place)

This fixes #2 as well