### PR TITLE
Update to Nebula 1.10.3 and hassio-base:20.1.1

### DIFF
--- a/nebula/Dockerfile
+++ b/nebula/Dockerfile
@@ -19,7 +19,7 @@ RUN \
 #        openresolv=3.12.0-r0 \
 #        wireguard-tools=1.0.20210914-r0 \
     \
-    && git clone --branch "v1.7.2" --depth=1 \
+    && git clone --branch "v1.10.3" --depth=1 \
         "https://github.com/slackhq/nebula.git" /tmp/nebula \
     \
     && cd /tmp/nebula \

--- a/nebula/Dockerfile
+++ b/nebula/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:17.2.3
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
 
 FROM ${BUILD_FROM}
 

--- a/nebula/build.yaml
+++ b/nebula/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:17.2.3
-  amd64: ghcr.io/hassio-addons/base/amd64:17.2.3
-  armhf: ghcr.io/hassio-addons/base/armhf:17.2.3
-  armv7: ghcr.io/hassio-addons/base/armv7:17.2.3
-  i386: ghcr.io/hassio-addons/base/i386:17.2.3
+  aarch64: ghcr.io/hassio-addons/base/aarch64:20.1.1
+  amd64: ghcr.io/hassio-addons/base/amd64:20.1.1
+  armhf: ghcr.io/hassio-addons/base/armhf:20.1.1
+  armv7: ghcr.io/hassio-addons/base/armv7:20.1.1
+  i386: ghcr.io/hassio-addons/base/i386:20.1.1


### PR DESCRIPTION
This gets the V2 certificates working and runs it as Nebula 1.10.3. Tested in Home Assistant Yellow running:

```
Installation method Home Assistant OS
Core 2026.5.4
Supervisor 2026.05.0
Operating System 17.3
Frontend 20260429.4
```