### PR TITLE
Add GitHub Actions build CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    name: Build addon (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            build_from: ghcr.io/hassio-addons/base/amd64:20.1.1
+            platform: linux/amd64
+          # arm64 and armv7 builds via QEMU emulation are very slow when
+          # compiling Nebula from source (~30-45 min each). They will be
+          # re-enabled once the Dockerfile switches to downloading pre-built
+          # Nebula binaries instead of compiling from source.
+          # - arch: aarch64
+          #   build_from: ghcr.io/hassio-addons/base/aarch64:20.1.1
+          #   platform: linux/arm64
+          # - arch: armv7
+          #   build_from: ghcr.io/hassio-addons/base/armv7:20.1.1
+          #   platform: linux/arm/v7
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./nebula
+          file: ./nebula/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: false
+          # BUILD_FROM must stay in sync with the matching arch entry in build.yaml
+          build-args: |
+            BUILD_FROM=${{ matrix.build_from }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that validates the Docker build on every push to `main` and every PR targeting `main`.

## What it does

- Builds the addon Dockerfile for **amd64** using the base image from `build.yaml`
- Runs on GitHub's free hosted runners — no cost for public repos
- `push: false` — just validates the build, doesn't push anywhere

## Why only amd64 for now

arm64 and armv7 matrix entries are in the workflow but commented out. Building Nebula from source under QEMU emulation takes 30–45 minutes per arch, which makes CI painful. They'll be uncommented when the Dockerfile is switched to downloading pre-built Nebula binaries (planned follow-up), at which point all arch builds will complete in ~1–2 minutes each.

## Merge order

Merging this before PR #22 means that PR will automatically get a build check run against it.