### PR TITLE
Switch to pre-built Nebula binaries; enable multi-arch CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,6 @@ jobs:
           - arch: aarch64
             build_from: ghcr.io/hassio-addons/base/aarch64:20.1.1
             platform: linux/arm64
-          - arch: armv7
-            build_from: ghcr.io/hassio-addons/base/armv7:20.1.1
-            platform: linux/arm/v7
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,20 +17,19 @@ jobs:
           - arch: amd64
             build_from: ghcr.io/hassio-addons/base/amd64:20.1.1
             platform: linux/amd64
-          # arm64 and armv7 builds via QEMU emulation are very slow when
-          # compiling Nebula from source (~30-45 min each). They will be
-          # re-enabled once the Dockerfile switches to downloading pre-built
-          # Nebula binaries instead of compiling from source.
-          # - arch: aarch64
-          #   build_from: ghcr.io/hassio-addons/base/aarch64:20.1.1
-          #   platform: linux/arm64
-          # - arch: armv7
-          #   build_from: ghcr.io/hassio-addons/base/armv7:20.1.1
-          #   platform: linux/arm/v7
+          - arch: aarch64
+            build_from: ghcr.io/hassio-addons/base/aarch64:20.1.1
+            platform: linux/arm64
+          - arch: armv7
+            build_from: ghcr.io/hassio-addons/base/armv7:20.1.1
+            platform: linux/arm/v7
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/nebula/Dockerfile
+++ b/nebula/Dockerfile
@@ -1,37 +1,39 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:20.1.1
 
 FROM ${BUILD_FROM}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Build Nebula
+# Docker buildx sets these automatically based on the target --platform.
+# The HA build system passes BUILD_FROM per arch; TARGETARCH/TARGETVARIANT
+# are used here to select the matching pre-built Nebula binary.
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+# Install Nebula from pre-built official release binaries.
+# Checksums from:
+# https://github.com/slackhq/nebula/releases/download/v1.10.3/SHASUM256.txt
 RUN \
-    apk add --no-cache --virtual .build-dependencies \
-        build-base \
-        git \
+    case "${TARGETARCH}${TARGETVARIANT}" in \
+        "amd64")  NEBULA_ARCH="amd64";  NEBULA_SHA256="99ac335caeb69d02a6b6b00a3d4b5d0a36ec3971df480a1cc50e6db378342955" ;; \
+        "arm64")  NEBULA_ARCH="arm64";  NEBULA_SHA256="69b2764b0c27b04e4f3fb47764cf330555beb5a49e62e045ed5f208a14341343" ;; \
+        "armv7")  NEBULA_ARCH="arm-7";  NEBULA_SHA256="b4d557a396fd5d62848a5358008f5410f6eb66ea12f7bf8d98193a82b010393f" ;; \
+        "armv6")  NEBULA_ARCH="arm-6";  NEBULA_SHA256="3a451e9e8a0ca08811dbaab897f98574e0e79a2a6d017a1cb5640ea35022c1ea" ;; \
+        "386")    NEBULA_ARCH="386";    NEBULA_SHA256="5e586f5bc7e6c28abe813ebd765f39405c4a75cb9ea765a49e09bee4366c0d89" ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}${TARGETVARIANT}" >&2; exit 1 ;; \
+    esac \
     \
     && apk add --no-cache \
-        go \
         iptables \
         yq \
         bind-tools \
-#        libqrencode=4.1.1-r0 \
-#        openresolv=3.12.0-r0 \
-#        wireguard-tools=1.0.20210914-r0 \
     \
-    && git clone --branch "v1.10.3" --depth=1 \
-        "https://github.com/slackhq/nebula.git" /tmp/nebula \
-    \
-    && cd /tmp/nebula \
-    && make bin \
-    && mv nebula /usr/bin/nebula \
-    && mv nebula-cert /usr/bin/nebula-cert \
-#    && chmod +x /usr/bin/nebula \
-#    && chmod +x /usr/bin/nebula-cert \
-    \
-    && rm -f -r /tmp/* \
-    && apk del --no-cache --purge \
-        .build-dependencies \
-        go
+    && wget -qO /tmp/nebula.tar.gz \
+        "https://github.com/slackhq/nebula/releases/download/v1.10.3/nebula-linux-${NEBULA_ARCH}.tar.gz" \
+    && echo "${NEBULA_SHA256}  /tmp/nebula.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/nebula.tar.gz -C /tmp \
+    && mv /tmp/nebula /usr/bin/nebula \
+    && mv /tmp/nebula-cert /usr/bin/nebula-cert \
+    && rm /tmp/nebula.tar.gz
 
 COPY rootfs /

--- a/nebula/build.yaml
+++ b/nebula/build.yaml
@@ -2,6 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base/aarch64:20.1.1
   amd64: ghcr.io/hassio-addons/base/amd64:20.1.1
-  armhf: ghcr.io/hassio-addons/base/armhf:20.1.1
-  armv7: ghcr.io/hassio-addons/base/armv7:20.1.1
-  i386: ghcr.io/hassio-addons/base/i386:20.1.1

--- a/nebula/config.yaml
+++ b/nebula/config.yaml
@@ -8,9 +8,6 @@ host_network: true
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
-  - i386
 ports:
   4242/udp: 4242
 ports_description:


### PR DESCRIPTION
## Summary

Replaces the compile-from-source Dockerfile with one that downloads the official pre-built Nebula binary from the GitHub release, and cleans up architecture support to match what hassio-addons/base actually publishes.

## Motivation

Building Nebula from source required pinning specific versions of Go, build-base, and git from Alpine. These pins have broken installations repeatedly as Alpine packages drift (#3, #12, #16) — the same class of breakage, over and over. Since we're already trusting the `slackhq/nebula` GitHub repo for source code, trusting their published release artifacts (verified by SHA256) is no different and eliminates the whole problem.

Thanks to @buildmine10, @DavidMSCode, @wplinge, and everyone who's hit the Alpine package breakage issue and had to fork or wait — this should be the last time it happens.

## Dockerfile changes

- Downloads the official `nebula-linux-{arch}.tar.gz` from the v1.10.3 GitHub release
- Verifies SHA256 checksum against values from the official `SHASUM256.txt` before extracting — build fails hard if anything doesn't match
- Uses Docker's `TARGETARCH`/`TARGETVARIANT` build args (set automatically by buildx) to select the right binary for each arch
- Removes Go, git, and build-base as dependencies — only `iptables`, `yq`, and `bind-tools` remain
- Build time: ~10 minutes → ~30 seconds

**When upgrading Nebula in future:** update the version string in the download URL and the five SHA256 values in the case statement (sourced from the new release's `SHASUM256.txt`).

## Architecture cleanup

`ghcr.io/hassio-addons/base` stopped publishing images for armv7, armhf, and i386 after v18.x. Those entries in `build.yaml` and `config.yaml` have been broken since the base image was bumped to v20.1.1 in #18 — any user on those architectures would have been unable to install. Removed from `config.yaml`, `build.yaml`, and CI.

## CI changes

- Builds for amd64 and aarch64 (the two supported arches)
- Both use QEMU for cross-platform builds — fast now since there's no compilation under emulation